### PR TITLE
feat: adiciona páginas de dicas

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -14,6 +14,7 @@ import routes from './routes.js'
 // Import analytics stuff 
 // import Abalytics from './abalytics.js'
 import { storage } from './storage.js'
+import { Tips } from './tips.js'
 
 // Import main app component
 import App from '../app.f7.html'
@@ -70,6 +71,7 @@ var app = new Framework7({
 
       // Abalytics.init(f7)
       storage.init(f7)
+      new Tips(f7);
     },
   },
 })

--- a/src/js/isenabled.js
+++ b/src/js/isenabled.js
@@ -32,9 +32,7 @@ var IsEnabled = {
 
     reasonsPage: true,
 
-    leisurePage: true,
-
-    sleepTipsPage: true,
+    tipsPage: true,
 
     wellnessQuizPage: true,
     

--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -17,8 +17,7 @@ import PreventionPage from "../pages/prevention.f7.html";
 import ReasonsPage from "../pages/reasons.f7.html";
 import ContactPage from "../pages/contact.f7.html";
 import HealthTipsPage from '../pages/health-tips.f7.html';
-import LeisureTipsPage from '../pages/leisure-tips.f7.html';
-import SleepTipsPage from '../pages/sleep-tips.f7.html';
+import TipsPage from '../pages/tips.f7.html';
 import WellnessQuizPage from '../pages/wellness-quiz.f7.html';
 import HeartBeatPage from '../pages/hr.f7.html';
 
@@ -225,25 +224,14 @@ const healthTipsPageRoute = function () {
 }
 
 
-const leisureTipsPageRoute = function () {
+const tipsPageRoute = function () {
   let route = {
-    path: '/leisure-tips/',
-    component: LeisureTipsPage,
+    path: '/tips/:category',
+    component: TipsPage,
     // beforeEnter: authenticated,
   };
 
-  if (IsEnabled.leisurePage) return route;
-}
-
-
-const sleepTipsPagePageRoute = function () {
-  let route = {
-    path: '/sleep-tips/',
-    component: SleepTipsPage,
-    // beforeEnter: authenticated,
-  };
-
-  if (IsEnabled.sleepTipsPage) return route;
+  if (IsEnabled.tipsPage) return route;
 }
 
 
@@ -275,8 +263,7 @@ var routes = [
   aboutPageRoute(),
   wellnessQuizPageRoute(),
   heartBeatPageRoute(),
-  leisureTipsPageRoute(),
-  sleepTipsPagePageRoute(),
+  tipsPageRoute(),
 
   // Routes imported from: app-covid
   wherePageRoute(),

--- a/src/js/tips.js
+++ b/src/js/tips.js
@@ -1,0 +1,42 @@
+export class Tips {
+	constructor(app) {
+		this.app = app;
+		app.tips = this;
+	}
+
+	getActivityTips() {
+        var self = this;
+        var app = self.app;
+        return app.request.promise.json('static/example-data/activity-tips.json')
+        .then((res) => {
+            return res.data;
+        });  
+    }
+
+    getSleepTips() {
+        var self = this;
+        var app = self.app;
+        return app.request.promise.json('static/example-data/sleep-tips.json')
+        .then((res) => {
+            return res.data;
+        });        
+    }
+
+    getFeedingTips() {
+        var self = this;
+        var app = self.app;
+        return app.request.promise.json('static/example-data/feeding-tips.json')
+        .then((res) => {
+            return res.data;
+        });
+    }
+
+    getLeisureTips() {
+        var self = this;
+        var app = self.app;
+        return app.request.promise.json('static/example-data/leisure-tips.json')
+        .then((res) => {
+            return res.data;
+        });
+    }
+};

--- a/src/pages/services.f7.html
+++ b/src/pages/services.f7.html
@@ -38,10 +38,31 @@
                 </div>
             </a>
 
-            <a href="/sleep-tips/" class="menu-grid__item">
+            <a href="/tips/sleep" class="menu-grid__item">
                 <div class="item-inner">
                     <img src="static/images/sleep.png" class="menu-grid__icon">
                     <div class="item-title">Dicas de Sono</div>
+                </div>
+            </a>
+
+            <a href="/tips/feeding" class="menu-grid__item">
+                <div class="item-inner">
+                    <img src="static/images/health-food.png" class="menu-grid__icon">
+                    <div class="item-title">Dicas de Alimentação</div>
+                </div>
+            </a>
+
+            <a href="/tips/activity" class="menu-grid__item">
+                <div class="item-inner">
+                    <img src="static/images/exercise.png" class="menu-grid__icon">
+                    <div class="item-title">Dicas de Atividade Física</div>
+                </div>
+            </a>
+
+            <a href="/tips/leisure" class="menu-grid__item">
+                <div class="item-inner">
+                    <img src="static/images/leisure.png" class="menu-grid__icon">
+                    <div class="item-title">Dicas de Lazer</div>
                 </div>
             </a>
             
@@ -49,13 +70,6 @@
                 <div class="item-inner">
                     <img src="static/images/go-to-therapy.png" class="menu-grid__icon">
                     <div class="item-title">Atendimento Emergencial</div>
-                </div>
-            </a>
-
-            <a href="/leisure-tips/" class="menu-grid__item">
-                <div class="item-inner">
-                    <img src="static/images/leisure.png" class="menu-grid__icon">
-                    <div class="item-title">Lazer</div>
                 </div>
             </a>
           

--- a/src/pages/tips.f7.html
+++ b/src/pages/tips.f7.html
@@ -1,0 +1,150 @@
+<template>
+    <div class="page" data-name="infected">
+        <div class="navbar">
+            <div class="navbar-bg"></div>
+            <div class="navbar-inner sliding">
+                <div class="left">
+                    <a href="#" class="link back">
+                        <i class="icon icon-back"></i>
+                        <span class="if-not-md">Voltar</span>
+                    </a>
+                </div>
+                <div class="title">{{ pageTitle }}</div>
+            </div>
+        </div>
+
+        <!-- Load Facebook SDK for JavaScript -->
+        <script async defer src="https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v3.2"></script>
+
+        <div class="page-content">
+            {{#if content}}
+                {{#each content}}
+                    <div id="sleep-tip-{{this.id}}" class="block">
+                        <div class="list media-list prevention-list">
+                            <ul>
+                                <li>
+                                    <div class="item-content margin-top-half">
+                                        {{#if this.icon}}
+                                        <div class="item-media">
+                                            <img src="{{this.icon}}" alt="hand-wash" height="60">
+                                        </div>
+                                        {{/if}}
+                                        <div class="item-inner">
+                                            {{#if this.title}}
+                                                <div class="item-title">{{this.title}}</div>
+                                            {{/if}}
+                                            {{#if this.text}}
+                                                <div class="item-text">
+                                                    {{this.text}}
+                                                </div>
+                                            {{/if}}
+                                        </div>
+                                    </div>
+                                </li>
+                                {{#if this.image}}
+                                    <li class="padding">
+                                        <div class="card-content"> <img src="{{this.image}}"
+                                            width="100%" /></div>
+                                    </li>
+                                {{/if}}
+                                {{#if this.video}}
+                                    <li class="padding">
+                                        <div class="reponsive reponsive--16x9">
+                                            <iframe class="reponsive__item" src="{{this.video}}" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+                                        </div>
+                                    </li>
+                                {{/if}}
+                            </ul>
+                        </div>
+                    </div>
+                {{/each}}
+            {{else}}
+                <div class="block">
+                    <div class="list media-list prevention-list">
+                        <ul>
+                            <li>
+                                <div class="item-content margin-top-half">
+                                    <div class="item-inner">
+                                        <div class="item-text">
+                                            <p>Em breve serão adicionadas dicas sobre como dormir melhor!</p>
+                                        </div>
+                                    </div>
+                                </div>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            
+            {{/if}}
+        </div>
+    </div>
+</template>
+<script>
+    export default {
+        data: function () {
+            return {
+                content: null,
+                pageTitle: null
+            }
+        },
+        methods: {
+            loadData: function (e, category) {
+                var self = this;
+                var app = self.$app;
+                app.request.json('static/example-data/'+category+'-tips.json', function (data) {
+                    self.$setState({
+                        content: data,
+                    });
+                });
+
+                switch (category) {
+                    case 'sleep':
+                        self.$setState({
+                            pageTitle: "Dicas de Sono",
+                        });
+                        break;
+                    case 'feeding':
+                        self.$setState({
+                            pageTitle: "Dicas de Alimentação",
+                        });
+                        break;
+                    case 'activity':
+                        self.$setState({
+                            pageTitle: "Dicas de Atividade Física",
+                        });
+                        break;
+                    case 'leisure':
+                        self.$setState({
+                            pageTitle: "Dicas de Lazer",
+                        });
+                        break;
+                }
+            },
+        },
+        on: {
+            pageInit: function (e, page) {
+                this.loadData(e, page.route.params.category)
+            },
+        },
+    };
+</script>
+
+<style>
+    .reponsive {
+        position: relative;
+    }
+
+    .reponsive--16x9 {
+        padding-top: 56.25%
+            /* 9/16 */
+        ;
+    }
+
+    .reponsive__item {
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+    }
+</style>

--- a/src/pages/tips.f7.html
+++ b/src/pages/tips.f7.html
@@ -66,7 +66,7 @@
                                 <div class="item-content margin-top-half">
                                     <div class="item-inner">
                                         <div class="item-text">
-                                            <p>Em breve serão adicionadas dicas sobre como dormir melhor!</p>
+                                            <p>Em breve as dicas serão adicionadas!</p>
                                         </div>
                                     </div>
                                 </div>
@@ -88,33 +88,32 @@
             }
         },
         methods: {
-            loadData: function (e, category) {
+            loadData: async function (e, category) {
                 var self = this;
                 var app = self.$app;
-                app.request.json('static/example-data/'+category+'-tips.json', function (data) {
-                    self.$setState({
-                        content: data,
-                    });
-                });
 
                 switch (category) {
                     case 'sleep':
                         self.$setState({
+                            content: await app.tips.getSleepTips(),
                             pageTitle: "Dicas de Sono",
                         });
                         break;
                     case 'feeding':
                         self.$setState({
+                            content: await app.tips.getFeedingTips(),
                             pageTitle: "Dicas de Alimentação",
                         });
                         break;
                     case 'activity':
                         self.$setState({
+                            content: await app.tips.getActivityTips(),
                             pageTitle: "Dicas de Atividade Física",
                         });
                         break;
                     case 'leisure':
                         self.$setState({
+                            content: await app.tips.getLeisureTips(),
                             pageTitle: "Dicas de Lazer",
                         });
                         break;

--- a/src/static/example-data/activity-tips.json
+++ b/src/static/example-data/activity-tips.json
@@ -1,0 +1,19 @@
+[
+    {
+        "id": 1,
+        "title": "Caminhada",
+        "text": "A caminhada pode ser uma das maneiras mais simples de vencer o sedentarismo. Que tal começar agora?",
+        "video": null,
+        "image": "https://cdn.pixabay.com/photo/2017/08/12/19/01/legs-2635038_960_720.jpg",
+        "icon": null
+        
+    },
+    {
+        "id": 2,
+        "title": "Pular corda",
+        "text": "Além de poder ser realizada em praticamente qualquer espaço é uma boa forma de ganhar condicionamento físico.",
+        "video": null,
+        "image": null,
+        "icon": null
+    }
+]

--- a/src/static/example-data/feeding-tips.json
+++ b/src/static/example-data/feeding-tips.json
@@ -1,0 +1,27 @@
+[
+    {
+        "id": 1,
+        "title": null,
+        "text": "Evite a ingestão de alimentos processados.",
+        "video": null,
+        "image": null,
+        "icon": "static/images/health-food.png"
+        
+    },
+    {
+        "id": 2,
+        "title": "Fibras",
+        "text": "Fibras são extremamente importantes para nosso organismo. Uma dieta rica em frutas, legumes e verduras é uma forma simples de inserir fibras na alimentação.",
+        "video": null,
+        "image": null,
+        "icon": null
+    },
+    {
+        "id": 3,
+        "title": null,
+        "text": "Busque ingerir aproximadamente dois litros de água todos os dias.",
+        "video": null,
+        "image": null,
+        "icon": "https://cdn.pixabay.com/photo/2019/05/18/12/58/water-4211792_960_720.png"
+    }
+]


### PR DESCRIPTION
Adiciona a página responsável pela exibição das dicas no aplicativo. A mesma tela é responsável por todas as categorias de dicas e o conteúdo exibido varia de acordo com o parâmetro passado pela URL. Como a mesma tela é utilizada para todos os tipos de dicas esse PR resolve todas as issues relacionadas na issue #26.

Adicionei também uma classe responsavel por acessar as dicas para tornar mais simples seu acesso em todo o app.


Fix: #26, #27 e #30.